### PR TITLE
Implementation of lastactcached

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,15 +417,17 @@ curl -sG 'http://localhost:3100/loki/api/v1/query_range' \
 
 ## TODO / Future Work
 
-### Promote `lastact` into `puzzle_view` and re-evaluate caching strategy
-**Context:** The `/all` and `/allcached` endpoints return data from `puzzle_view`, which currently does NOT include `lastact` (last activity timestamp). The frontend fetches this separately. Promoting `lastact` into `puzzle_view` would let the cached response include it, reducing extra queries.
+### `lastactcached` — cached last activity in `/all` response
 
-**Caching rule (current):** Cache is only invalidated for puzzle and round *structural* changes: status transitions, creation, deletion, round completion. Solver assignment/unassignment intentionally does NOT invalidate — the 15-second TTL (in `pbcachelib.py`) handles staleness for `cursolvers`. This keeps cache hit rates high during active solving (>90% observed during January 2026 hunt even with the old per-assignment invalidation).
+`lastactcached` is now included in every puzzle in the `/all` and `/allcached` responses, and in `GET /puzzles/<id>` responses. It provides a cached approximation of `lastact` for external utilities that consume `/all`, avoiding N+1 queries.
 
-**When `lastact` is added to `puzzle_view`:** The current simple single-key cache (`puzzleboss:all` in memcache) will need re-evaluation. Activity timestamps change constantly during a hunt. Options to consider:
-- Per-puzzle cache keys (invalidate only the affected puzzle)
-- Separate cache for static structure vs. volatile fields (lastact, cursolvers, sheetcount)
-- Server-sent events or websocket push instead of polling + cache
-- Hybrid: cache structural data with long TTL, overlay volatile fields from DB on each request
+**How it works:**
+- On the `/all` cache cold path (once per 15s TTL), a single bulk `SELECT ... MAX(time) GROUP BY puzzle_id` query fetches the most recent activity for all puzzles at once and injects `lastactcached` into each puzzle dict before caching.
+- On cache hit: `lastactcached` comes back in the cached blob with no DB query.
+- `GET /puzzles/<id>`: reads `lastactcached` from the `puzzleboss:all` cache key if warm; falls back to a DB query if cold (never returns null).
+- `time` in `lastactcached` is always an ISO 8601 string (e.g. `"2026-03-29T21:13:27"`).
+- The existing `lastact` field on `GET /puzzles/<id>` is unchanged — always fresh from DB.
+
+**Caching rule (current):** Cache is only invalidated for puzzle and round *structural* changes: status transitions, creation, deletion, round completion. Solver assignment/unassignment intentionally does NOT invalidate — the 15-second TTL (in `pbcachelib.py`) handles staleness for `cursolvers` and `lastactcached`. This keeps cache hit rates high during active solving (>90% observed during January 2026 hunt).
 
 **Data point:** January 2026 hunt had >90% cache hit rate with 60s TTL and per-assignment invalidation. Current TTL is 15s with structural-only invalidation — monitor hit rate in next hunt to compare.

--- a/pblib.py
+++ b/pblib.py
@@ -687,7 +687,7 @@ def get_last_activity_for_puzzle(puzzle_id, conn):
     puzzle_id = int(puzzle_id)
     cursor = conn.cursor()
     cursor.execute(
-        "SELECT * from activity where puzzle_id = %s ORDER BY time DESC LIMIT 1",
+        "SELECT * from activity where puzzle_id = %s ORDER BY time DESC, id DESC LIMIT 1",
         (puzzle_id,),
     )
     return cursor.fetchone()

--- a/pbrest.py
+++ b/pbrest.py
@@ -236,6 +236,40 @@ def _get_all_from_db():
     for puzzle in puzzle_view:
         all_puzzles[puzzle["id"]] = puzzle
 
+    # Fetch most recent activity per puzzle in one query and inject as
+    # lastactcached. This is included in the /all response so external
+    # utilities get a cached approximation of lastact without N+1 queries.
+    # time is serialized to ISO string here so json.dumps() can cache it.
+    try:
+        conn, cursor = _read_cursor()
+        cursor.execute(
+            """
+            SELECT a.*
+            FROM activity a
+            INNER JOIN (
+                SELECT puzzle_id, MAX(time) AS max_time
+                FROM activity
+                GROUP BY puzzle_id
+            ) latest ON a.puzzle_id = latest.puzzle_id
+                    AND a.time = latest.max_time
+            ORDER BY a.id DESC
+            """
+        )
+        for row in cursor.fetchall():
+            pid = row["puzzle_id"]
+            # ORDER BY a.id DESC means the first row per puzzle_id is the
+            # most recent; skip subsequent rows for the same puzzle.
+            if pid in all_puzzles and "lastactcached" not in all_puzzles[pid]:
+                row["time"] = row["time"].isoformat() if row.get("time") else None
+                all_puzzles[pid]["lastactcached"] = row
+    except Exception as e:
+        debug_log(2, f"Failed to fetch lastactcached: {e}")
+        # Non-fatal: puzzles without lastactcached will fall back in callers
+
+    # Ensure all puzzles have the key (None for puzzles with no activity yet)
+    for puzzle in all_puzzles.values():
+        puzzle.setdefault("lastactcached", None)
+
     try:
         conn, cursor = _read_cursor()
         cursor.execute("SELECT * from round_view")
@@ -532,11 +566,37 @@ def get_one_puzzle(id):
 
     debug_log(5, f"fetched puzzle {id}: {puzzle}")
 
-    # Include lastact to reduce HTTP round-trips for clients
+    # Include lastact (always fresh from DB) and lastactcached (from /all
+    # cache if warm, DB fallback if cold) to reduce HTTP round-trips.
+    lastact = get_last_activity_for_puzzle(id)
+
+    lastactcached = None
+    cached_blob = cache_get(MEMCACHE_CACHE_KEY)
+    if cached_blob:
+        try:
+            cached_data = json.loads(cached_blob)
+            for round_data in cached_data.get("rounds", []):
+                for p in round_data.get("puzzles", []):
+                    if p.get("id") == int(id):
+                        lastactcached = p.get("lastactcached")
+                        break
+                if lastactcached is not None:
+                    break
+        except Exception as e:
+            debug_log(3, f"Failed to read lastactcached from cache for puzzle {id}: {e}")
+
+    if lastactcached is None:
+        # Cache cold or puzzle not found — fall back to DB (never return null)
+        row = get_last_activity_for_puzzle(id)
+        if row and row.get("time"):
+            row["time"] = row["time"].isoformat()
+        lastactcached = row
+
     return {
         "status": "ok",
         "puzzle": puzzle,
-        "lastact": get_last_activity_for_puzzle(id),
+        "lastact": lastact,
+        "lastactcached": lastactcached,
     }
 
 

--- a/pbrest.py
+++ b/pbrest.py
@@ -222,6 +222,23 @@ def _promote_top_hint(cursor):
         debug_log(3, f"Auto-promoted hint {top['id']} to 'ready'")
 
 
+# Sentinel for "puzzle not found in cache" — distinct from None (found, no activity).
+_CACHE_MISS = object()
+
+
+def _serialize_activity_for_cache(row):
+    """Return a copy of an activity row with time converted to ISO 8601 string.
+
+    MySQL returns time as a datetime object, which json.dumps() cannot serialize.
+    Used when injecting activity rows into data that will be stored in memcache.
+    """
+    if not row or not row.get("time"):
+        return row
+    row = dict(row)
+    row["time"] = row["time"].isoformat()
+    return row
+
+
 def _get_all_from_db():
     """Internal function to fetch all rounds/puzzles from database."""
     debug_log(4, "fetching all from database")
@@ -260,11 +277,10 @@ def _get_all_from_db():
             # ORDER BY a.id DESC means the first row per puzzle_id is the
             # most recent; skip subsequent rows for the same puzzle.
             if pid in all_puzzles and "lastactcached" not in all_puzzles[pid]:
-                row["time"] = row["time"].isoformat() if row.get("time") else None
-                all_puzzles[pid]["lastactcached"] = row
+                all_puzzles[pid]["lastactcached"] = _serialize_activity_for_cache(row)
     except Exception as e:
         debug_log(2, f"Failed to fetch lastactcached: {e}")
-        # Non-fatal: puzzles without lastactcached will fall back in callers
+        # Non-fatal: affected puzzles get lastactcached=None via setdefault below
 
     # Ensure all puzzles have the key (None for puzzles with no activity yet)
     for puzzle in all_puzzles.values():
@@ -570,8 +586,7 @@ def get_one_puzzle(id):
     # cache if warm, DB fallback if cold) to reduce HTTP round-trips.
     lastact = get_last_activity_for_puzzle(id)
 
-    _SENTINEL = object()  # distinguishes "not found in cache" from "found, value is None"
-    lastactcached = _SENTINEL
+    lastactcached = _CACHE_MISS
     cached_blob = cache_get(MEMCACHE_CACHE_KEY)
     if cached_blob:
         try:
@@ -581,19 +596,15 @@ def get_one_puzzle(id):
                     if p.get("id") == int(id):
                         lastactcached = p.get("lastactcached")  # may legitimately be None
                         break
-                if lastactcached is not _SENTINEL:
+                if lastactcached is not _CACHE_MISS:
                     break
         except Exception as e:
             debug_log(3, f"Failed to read lastactcached from cache for puzzle {id}: {e}")
 
-    if lastactcached is _SENTINEL:
-        # Cache cold or puzzle not found in cache — reuse already-fetched lastact
-        # (same DB row, no second query needed)
-        row = lastact
-        if row and row.get("time") and not isinstance(row["time"], str):
-            row = dict(row)  # copy before mutating — lastact is returned as-is
-            row["time"] = row["time"].isoformat()
-        lastactcached = row
+    if lastactcached is _CACHE_MISS:
+        # Cache cold or puzzle not found — reuse already-fetched lastact
+        # (avoids a second identical DB query; copy before mutating time)
+        lastactcached = _serialize_activity_for_cache(lastact)
 
     return {
         "status": "ok",

--- a/pbrest.py
+++ b/pbrest.py
@@ -570,7 +570,8 @@ def get_one_puzzle(id):
     # cache if warm, DB fallback if cold) to reduce HTTP round-trips.
     lastact = get_last_activity_for_puzzle(id)
 
-    lastactcached = None
+    _SENTINEL = object()  # distinguishes "not found in cache" from "found, value is None"
+    lastactcached = _SENTINEL
     cached_blob = cache_get(MEMCACHE_CACHE_KEY)
     if cached_blob:
         try:
@@ -578,17 +579,19 @@ def get_one_puzzle(id):
             for round_data in cached_data.get("rounds", []):
                 for p in round_data.get("puzzles", []):
                     if p.get("id") == int(id):
-                        lastactcached = p.get("lastactcached")
+                        lastactcached = p.get("lastactcached")  # may legitimately be None
                         break
-                if lastactcached is not None:
+                if lastactcached is not _SENTINEL:
                     break
         except Exception as e:
             debug_log(3, f"Failed to read lastactcached from cache for puzzle {id}: {e}")
 
-    if lastactcached is None:
-        # Cache cold or puzzle not found — fall back to DB (never return null)
-        row = get_last_activity_for_puzzle(id)
-        if row and row.get("time"):
+    if lastactcached is _SENTINEL:
+        # Cache cold or puzzle not found in cache — reuse already-fetched lastact
+        # (same DB row, no second query needed)
+        row = lastact
+        if row and row.get("time") and not isinstance(row["time"], str):
+            row = dict(row)  # copy before mutating — lastact is returned as-is
             row["time"] = row["time"].isoformat()
         lastactcached = row
 

--- a/pbrest.py
+++ b/pbrest.py
@@ -222,10 +222,6 @@ def _promote_top_hint(cursor):
         debug_log(3, f"Auto-promoted hint {top['id']} to 'ready'")
 
 
-# Sentinel for "puzzle not found in cache" — distinct from None (found, no activity).
-_CACHE_MISS = object()
-
-
 def _serialize_activity_for_cache(row):
     """Return a copy of an activity row with time converted to ISO 8601 string.
 
@@ -586,25 +582,11 @@ def get_one_puzzle(id):
     # cache if warm, DB fallback if cold) to reduce HTTP round-trips.
     lastact = get_last_activity_for_puzzle(id)
 
-    lastactcached = _CACHE_MISS
-    cached_blob = cache_get(MEMCACHE_CACHE_KEY)
-    if cached_blob:
-        try:
-            cached_data = json.loads(cached_blob)
-            for round_data in cached_data.get("rounds", []):
-                for p in round_data.get("puzzles", []):
-                    if p.get("id") == int(id):
-                        lastactcached = p.get("lastactcached")  # may legitimately be None
-                        break
-                if lastactcached is not _CACHE_MISS:
-                    break
-        except Exception as e:
-            debug_log(3, f"Failed to read lastactcached from cache for puzzle {id}: {e}")
-
-    if lastactcached is _CACHE_MISS:
-        # Cache cold or puzzle not found — reuse already-fetched lastact
-        # (avoids a second identical DB query; copy before mutating time)
-        lastactcached = _serialize_activity_for_cache(lastact)
+    # lastactcached reuses the already-fetched lastact with time as ISO string.
+    # No cache lookup here — deserializing the full /all blob on every single-puzzle
+    # request is more expensive than the DB query already made for lastact.
+    # The caching benefit of lastactcached is for /all bulk consumers, not here.
+    lastactcached = _serialize_activity_for_cache(lastact)
 
     return {
         "status": "ok",

--- a/scripts/test_api_coverage.py
+++ b/scripts/test_api_coverage.py
@@ -61,6 +61,7 @@ class TestRunner:
         "Solver Reassignment",
         "Activity Tracking",
         "lastact Response Embedding",
+        "lastactcached Behavior",
         "Puzzle Activity Endpoint",
         "Solver Activity Endpoint",
         "Solver History",
@@ -1000,6 +1001,137 @@ class TestRunner:
         self.logger.log_operation(f"  ✓ GET /solvers/<id> embeds lastact (type={slastact.get('type')})")
 
         result.set_success("lastact embedding test completed successfully")
+
+    # ------------------------------------------------------------------
+    # Test 15c: lastactcached — /all and /puzzles/<id>
+    # Verifies lastactcached structure, consistency, ISO time format,
+    # and cache cold/hot behavior. TTL verification is skipped when
+    # memcache is not enabled (local dev without memcache).
+    # ------------------------------------------------------------------
+    def test_lastactcached(self, result: TestResult):
+        solvers = self.get_all_solvers()
+        puzzles = self.get_all_puzzles()
+        if not solvers or not puzzles:
+            result.fail("Need solvers and puzzles")
+            return
+
+        solver = solvers[0]
+        puzzle = puzzles[0]
+        pid = puzzle["id"]
+        sid = solver["id"]
+
+        # Trigger activity so lastactcached is non-null
+        self.assign_solver_to_puzzle(sid, pid)
+
+        # 1. /all includes lastactcached on every puzzle
+        all_data = self.api_get("/all")
+        found_puzzle = None
+        for rnd in all_data.get("rounds", []):
+            for p in rnd.get("puzzles", []):
+                if p.get("id") == pid:
+                    found_puzzle = p
+                    break
+            if found_puzzle:
+                break
+
+        if found_puzzle is None:
+            result.fail(f"Puzzle {pid} not found in /all response")
+            return
+        if "lastactcached" not in found_puzzle:
+            result.fail(f"Puzzle {pid} missing 'lastactcached' key in /all response")
+            return
+
+        lac_all = found_puzzle["lastactcached"]
+        if lac_all is None:
+            result.fail(f"Puzzle {pid} lastactcached is null in /all after assignment")
+            return
+
+        # Verify required fields
+        for key in ["id", "puzzle_id", "solver_id", "type", "time"]:
+            if key not in lac_all:
+                result.fail(f"/all lastactcached missing '{key}' field")
+                return
+
+        # time must be ISO 8601 string (not HTTP date, not datetime object)
+        t = lac_all["time"]
+        if not isinstance(t, str) or "T" not in t:
+            result.fail(f"/all lastactcached.time is not ISO 8601 string: {t!r}")
+            return
+        self.logger.log_operation(f"  ✓ /all lastactcached present (type={lac_all['type']}, time={t})")
+
+        # 2. GET /puzzles/<id> includes lastactcached
+        pdata = self.api_get(f"/puzzles/{pid}")
+        if "lastactcached" not in pdata:
+            result.fail(f"GET /puzzles/{pid} missing 'lastactcached' key")
+            return
+
+        lac_single = pdata["lastactcached"]
+        if lac_single is None:
+            result.fail(f"GET /puzzles/{pid} lastactcached is null (cache cold fallback should use DB)")
+            return
+
+        # time must also be ISO 8601 string
+        t2 = lac_single.get("time", "")
+        if not isinstance(t2, str) or "T" not in t2:
+            result.fail(f"GET /puzzles/<id> lastactcached.time is not ISO 8601 string: {t2!r}")
+            return
+        self.logger.log_operation(f"  ✓ GET /puzzles/<id> lastactcached present (type={lac_single['type']}, time={t2})")
+
+        # 3. lastactcached and lastact refer to the same activity record
+        la = pdata.get("lastact")
+        if la and lac_single:
+            if la.get("id") != lac_single.get("id"):
+                result.fail(
+                    f"lastact (id={la.get('id')}) and lastactcached (id={lac_single.get('id')}) "
+                    "disagree on most-recent activity — possible stale cache or tie-break bug"
+                )
+                return
+        self.logger.log_operation(f"  ✓ lastact and lastactcached agree (id={la.get('id')})")
+
+        # 4. After a new activity, lastactcached in /all eventually reflects it
+        #    (within TTL). We trigger new activity and verify /all updates
+        #    after cache expiry. Since local dev has no memcache, we just
+        #    verify the value changes on the next /all call (cache miss path).
+        ts = str(int(time.time()))
+        rounds = self.get_all_rounds()
+        if not rounds:
+            result.fail("No rounds found for new puzzle creation")
+            return
+        new_puzzle = self.create_puzzle(f"CachedLastactTest{ts}", rounds[0]["id"])
+        new_pid = new_puzzle["id"]
+
+        # New puzzle should have lastactcached from its creation activity
+        all_data2 = self.api_get("/all")
+        new_puz_in_all = None
+        for rnd in all_data2.get("rounds", []):
+            for p in rnd.get("puzzles", []):
+                if p.get("id") == new_pid:
+                    new_puz_in_all = p
+                    break
+            if new_puz_in_all:
+                break
+
+        if new_puz_in_all is None:
+            result.fail(f"New puzzle {new_pid} not in /all response")
+            return
+        if new_puz_in_all.get("lastactcached") is None:
+            result.fail(f"New puzzle {new_pid} has null lastactcached (should have 'create' activity)")
+            return
+        if new_puz_in_all["lastactcached"].get("type") != "create":
+            result.fail(
+                f"New puzzle lastactcached type={new_puz_in_all['lastactcached'].get('type')!r}, expected 'create'"
+            )
+            return
+        self.logger.log_operation(f"  ✓ Newly created puzzle has lastactcached type='create'")
+
+        # 5. GET /puzzles/<new_pid> also has lastactcached non-null (DB fallback)
+        new_pdata = self.api_get(f"/puzzles/{new_pid}")
+        if new_pdata.get("lastactcached") is None:
+            result.fail(f"GET /puzzles/{new_pid} lastactcached null (DB fallback should populate it)")
+            return
+        self.logger.log_operation(f"  ✓ GET /puzzles/<new_id> lastactcached non-null via DB fallback")
+
+        result.set_success("lastactcached test completed successfully")
 
     # ------------------------------------------------------------------
     # Test 16: Puzzle Activity Endpoint
@@ -2566,6 +2698,7 @@ class TestRunner:
             self.test_solver_reassignment,
             self.test_activity_tracking,
             self.test_lastact_embedding,
+            self.test_lastactcached,
             self.test_puzzle_activity_endpoint,
             self.test_solver_activity_endpoint,
             self.test_solver_history,

--- a/swag/getall.yaml
+++ b/swag/getall.yaml
@@ -81,6 +81,28 @@ responses:
                     sheetcount:
                       type: integer
                       description: Number of sheets/tabs in the puzzle's Google spreadsheet
+                    lastactcached:
+                      type: object
+                      nullable: true
+                      description: |
+                        Most recent activity for this puzzle, cached as part of the /all response
+                        (15s TTL). Null only for puzzles that have never had any activity.
+                        time is an ISO 8601 string. Use this instead of calling /puzzles/<id>/lastact
+                        per puzzle to avoid N+1 queries.
+                      properties:
+                        id:
+                          type: integer
+                        puzzle_id:
+                          type: integer
+                        solver_id:
+                          type: integer
+                        source:
+                          type: string
+                        type:
+                          type: string
+                        time:
+                          type: string
+                          description: ISO 8601 string (e.g. "2026-03-29T21:13:27")
   500:
     description: Error retrieving data
     schema:

--- a/swag/getallcached.yaml
+++ b/swag/getallcached.yaml
@@ -4,8 +4,12 @@ summary: Get all rounds and puzzles (cached)
 description: |
   Returns all rounds with their puzzles, using memcache for performance.
   Falls back to direct database query if cache is unavailable or disabled.
-  
+
   Note: This is now equivalent to /all - both endpoints use caching.
+
+  Each puzzle in the response includes a lastactcached field — the most recent
+  activity for that puzzle, cached as part of the /all response (15s TTL).
+  Use this instead of calling /puzzles/<id>/lastact per puzzle to avoid N+1 queries.
   
   Configure caching via config values:
   - MEMCACHE_ENABLED: 'true' or 'false'

--- a/swag/getpuzzleid.yaml
+++ b/swag/getpuzzleid.yaml
@@ -100,7 +100,7 @@ responses:
           lastact:
             type: object
             nullable: true
-            description: Most recent activity on this puzzle (null if none)
+            description: Most recent activity on this puzzle — always fresh from DB (null if no activity)
             properties:
               id:
                 type: integer
@@ -115,3 +115,25 @@ responses:
               time:
                 type: string
                 format: date-time
+          lastactcached:
+            type: object
+            nullable: true
+            description: |
+              Most recent activity on this puzzle — served from the /all cache (15s TTL) if warm,
+              falls back to a DB query if cold. time field is always an ISO 8601 string.
+              Intended for external utilities that need lastact data without N+1 queries.
+            properties:
+              id:
+                type: integer
+              puzzle_id:
+                type: integer
+              solver_id:
+                type: integer
+              source:
+                type: string
+              type:
+                type: string
+              time:
+                type: string
+                format: date-time
+                description: ISO 8601 string (e.g. "2026-03-29T21:13:27")

--- a/swag/getpuzzleid.yaml
+++ b/swag/getpuzzleid.yaml
@@ -100,7 +100,9 @@ responses:
           lastact:
             type: object
             nullable: true
-            description: Most recent activity on this puzzle — always fresh from DB (null if no activity)
+            description: |
+              Most recent activity on this puzzle — always fresh from DB (null if no activity).
+              time is serialized by Flask's JSON encoder (HTTP date format: "Sun, 29 Mar 2026 21:13:27 GMT").
             properties:
               id:
                 type: integer
@@ -114,7 +116,7 @@ responses:
                 type: string
               time:
                 type: string
-                format: date-time
+                description: HTTP date string as serialized by Flask (e.g. "Sun, 29 Mar 2026 21:13:27 GMT")
           lastactcached:
             type: object
             nullable: true


### PR DESCRIPTION
Provides a cached data component per puzzle that's also exposed in the /all pull.  Allows for external tools and some UI components that are willing to abide by a value that is up to 15 seconds stale, but get it as part of the /all pull with very minimal additional load on the DB and system.  The uncached /puzzle/##/lastact is a much more heavy call per puzzle but gives guaranteed current data.